### PR TITLE
:bug: fix(sh): fix script run error

### DIFF
--- a/docs/1panel-appstore.md
+++ b/docs/1panel-appstore.md
@@ -46,7 +46,7 @@ fi
 
 install_dir=$(which 1pctl | xargs grep '^BASE_DIR=' | cut -d'=' -f2)
 
-rm -rf $install_dir/1panel/resource/apps/local/oi-bot-1panel
+rm -rf $install_dir/1panel/resource/apps/local/OI-Bot-1panel
 
 if command -v wget > /dev/null; then
     wget -O $install_dir/1panel/resource/apps/local/oi-bot-1panel.zip https://github.com/talentestors/OI-Bot/archive/refs/heads/1panel.zip
@@ -64,7 +64,7 @@ if [ $? -ne 0 ]; then
 fi
 rm -rf $install_dir/1panel/resource/apps/local/oi-bot-1panel.zip
 rm -rf $install_dir/1panel/resource/apps/local/oi-bot
-mv $install_dir/1panel/resource/apps/local/oi-bot-1panel $install_dir/1panel/resource/apps/local/oi-bot
+mv $install_dir/1panel/resource/apps/local/OI-Bot-1panel $install_dir/1panel/resource/apps/local/oi-bot
 echo "success"
 ```
 


### PR DESCRIPTION
This pull request includes updates to the installation script in `docs/1panel-appstore.md` to fix case sensitivity issues in file paths related to the `OI-Bot` application. These changes ensure consistent handling of directory names during the installation process.

### Fixes for case sensitivity in file paths:

* Updated the `rm -rf` command to use `OI-Bot-1panel` instead of `oi-bot-1panel` when removing the old application directory. (`docs/1panel-appstore.md`, [docs/1panel-appstore.mdL49-R49](diffhunk://#diff-fd9dc5b57bf0b033bc528d9d45b7ef2bf6c3610640255da53cacffcb62d1276aL49-R49))
* Modified the `mv` command to correctly move the `OI-Bot-1panel` directory to `oi-bot`, ensuring proper case handling during the renaming process. (`docs/1panel-appstore.md`, [docs/1panel-appstore.mdL67-R67](diffhunk://#diff-fd9dc5b57bf0b033bc528d9d45b7ef2bf6c3610640255da53cacffcb62d1276aL67-R67))